### PR TITLE
When lint fails, don't fail the task, rather end it with done(false)

### DIFF
--- a/tasks/core/PhpLintTask.js
+++ b/tasks/core/PhpLintTask.js
@@ -39,6 +39,7 @@ PhpLintTask.prototype = {
 
 			if(err) {
 				done(false);
+				return;
 			}
 
 			done();


### PR DESCRIPTION
This is the same behavior as e.g. jshint has. It don't fail.warn when lint fails, but it ends with done(false).
