### PR TITLE
Short open tag option documentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,13 @@ module.exports = function(grunt) {
 		},
 
 		phplint: {
+			options: {
+			    phpArgs: {
+				"-l": null,
+				"--define": "short_open_tag=Off"
+			    },
+			    
+			},
 			good: ["test/rsrc/*-good.php"],
 			good_nocache: {
 				options: {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ var cfg = {
 		options: {
 			phpCmd: "/usr/bin/php", // Or "c:\EasyPHP-5.3.8.1\PHP.exe"
 			phpArgs: {
-				"-l": null
+				"-l": null,
+				"--define": "short_open_tag=Off"
 			},
 			spawnLimit: 10
 		},

--- a/test/rsrc/shortopentag-fail.php
+++ b/test/rsrc/shortopentag-fail.php
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title> Hello World in PHP </title>
+</head>
+<body>
+<?
+// Hello world in PHP
+ print("Hello World");
+?>
+</body>
+</html>

--- a/test/rsrc/shortopentag-good.php
+++ b/test/rsrc/shortopentag-good.php
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title> Hello World in PHP </title>
+</head>
+<body>
+<?php 
+	// Hello world in PHP
+	print("Hello World");
+	echo '';
+ ?>
+</body>
+</html>


### PR DESCRIPTION
Add option for disabling the short open tag PHP option.
Rationale: to use XHTML along with PHP we need to disable short open tag.
