### PR TITLE
Changed readme file to clarify passing in arguments, multiple options…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,46 @@ grunt.registerTask("default", ["phplint:good"]);
 
 By default we assume that the `php` command is in your path, if not, you can specify the full path to php like the example below.  You can also pass additional flags, like '-lf'.
 
+To pass parameters to an argument:
+
+```javascript
+var cfg = {
+	phplint: {
+		options: {
+			phpArgs: {
+				"-l": null,
+				"-d": null,
+				"-f": null,
+				"-c": "/usr/local/my-debug-config.ini"
+			}
+		},
+		good: ["test/rsrc/*-good.php"],
+		bad: ["test/rsrc/*-fail.php"]
+	}
+};
+```
+
+To pass multiple parameters to the -d argument:  
+
+```javascript
+var cfg = {
+	phplint: {
+		options: {
+			phpArgs: {
+				"-l": null,
+				"-d": null,
+				"-f": null,
+				"-d": ["display_errors", "display_startup_errors"]
+			}
+		},
+		good: ["test/rsrc/*-good.php"],
+		bad: ["test/rsrc/*-fail.php"]
+	}
+};
+```
+
+Passing in your own special configuration file or using -n to remove configuration files can be helpful when the lint fails but no errors are output to the stdin.  If you need to log these errors, consider a plugin like grunt-log to facilitate this.
+
 Lastly, if you want to limit the number of files we process at a time, set the spawnLimit.
 
 ```javascript
@@ -44,6 +84,8 @@ var cfg = {
 	}
 };
 ```
+
+
 
 ### Caching
 


### PR DESCRIPTION
…, and multiple parameters.  Since we're not sure if passing an array of arguments to -d is the correct configuration, this request may need to be amended or changed if it's not accurate.