### PR TITLE
Change the PHP open tags to the long version in the fixtures files

### DIFF
--- a/test/rsrc/index-fail.php
+++ b/test/rsrc/index-fail.php
@@ -3,7 +3,7 @@
 <TITLE> Hello World in PHP </TITLE>
 </HEAD>
 <BODY>
-<?
+<?php
 // Hello world in PHP
  print("Hello World");
 

--- a/test/rsrc/index-good.php
+++ b/test/rsrc/index-good.php
@@ -3,7 +3,7 @@
 <TITLE> Hello World in PHP </TITLE>
 </HEAD>
 <BODY>
-<?
+<?php
 // Hello world in PHP
  print("Hello World");
 ?>

--- a/test/rsrc/other-fail.php
+++ b/test/rsrc/other-fail.php
@@ -3,7 +3,7 @@
 <TITLE> Hello World in PHP </TITLE>
 </HEAD>
 <BODY>
-<?
+<?php
 // Hello world in PHP
  print("Hello World");
 

--- a/test/rsrc/other-good.php
+++ b/test/rsrc/other-good.php
@@ -3,7 +3,7 @@
 <TITLE> Hello World in PHP </TITLE>
 </HEAD>
 <BODY>
-<?
+<?php
 // Hello world in PHP
  print("Hello World");
 ?>

--- a/test/rsrc/third-fail.php
+++ b/test/rsrc/third-fail.php
@@ -3,7 +3,7 @@
 <TITLE> Hello World in PHP </TITLE>
 </HEAD>
 <BODY>
-<?
+<?php
 // Hello world in PHP
  print("Hello World");
 

--- a/test/rsrc/third-good.php
+++ b/test/rsrc/third-good.php
@@ -3,7 +3,7 @@
 <TITLE> Hello World in PHP </TITLE>
 </HEAD>
 <BODY>
-<?
+<?php
 // Hello world in PHP
  print("Hello World");
 ?>


### PR DESCRIPTION
The short_open_tag=on is not recommended and most of the linux
distributions ship the php.ini with this option turned off.
This means that the `php -l test/rsrc/index-fail.php` never throws error
because there is no PHP code in that file.
The long open tag (<?php) always works.