### PR TITLE
os.tmpDir() - deprecated #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ var cfg = {
 
 As of version 0.0.3, we cache previously hinted files to improve performance.  This is done by taking a hash of the contents of a file and checking it against previously successful linted files content hashes.
 
-By default, we will use the `os.tmpDir()` as the location for holding our swapped files (the files are empty, just placeholders).  To change this you can pass in a `swapPath` option:
+By default, we will use the `os.tmpdir()` as the location for holding our swapped files (the files are empty, just placeholders).  To change this you can pass in a `swapPath` option:
 
 ```javascript
 var cfg = {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -35,9 +35,9 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
     },
     "cache-swap": {
-      "version": "0.2.3",
-      "from": "cache-swap@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/cache-swap/-/cache-swap-0.2.3.tgz"
+      "version": "0.3.0",
+      "from": "cache-swap@0.3.0",
+      "resolved": "https://registry.npmjs.org/cache-swap/-/cache-swap-0.3.0.tgz"
     },
     "cli": {
       "version": "0.6.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "grunt": "~0.4.1",
-    "cache-swap": "~0.2.3"
+    "cache-swap": "~0.3.0"
   },
   "scripts": {
     "test": "npm run lint && mocha",

--- a/tasks/core/PhpLintTask.js
+++ b/tasks/core/PhpLintTask.js
@@ -19,7 +19,7 @@ function PhpLintTask(task) {
 
 	this.options = task.options({
 		spawnLimit: 10,
-		swapPath: os.tmpDir(),
+		swapPath: os.tmpdir(),
 		cache: true,
 		phpCmd: 'php'
 	});


### PR DESCRIPTION
* call [`os.tmpdir()`](https://nodejs.org/api/os.html#os_os_tmpdir) instead of the [deprecated `os.tmpDir()` alias](https://github.com/nodejs/node/pull/6739)
* include newer version of cache-swap with [tmpDir -> tmpdir issue fixed](https://github.com/jgable/cache-swap/commit/69fab2b7a5f76dc83790c1faef8598b84b70e559)

Full disclosure: Out of an abundance of caution, I just manually hot-dogged in the updated npm shrinkwrap entry for cache-swap because I didn't want to inadvertently break anything else with other dependencies. Not sure if that's frowned upon or not... is the preferred approach to just update all the things and hope nothing breaks?